### PR TITLE
fix: Reduce the use of any types in toast methods

### DIFF
--- a/src/components/toast.ts
+++ b/src/components/toast.ts
@@ -7,26 +7,44 @@ import {
   removeAllToast,
   getRemainingTimeForToast,
 } from './toast-store';
+import { ToastProps } from './types';
 
 export const toast = Object.assign(
-  (message: React.ReactNode, options?: Partial<any>) => {
-   return addToast({ ...options, message, type: 'custom' }); // Default to custom toast
+  (
+    message: React.ReactNode,
+    options?: Partial<Omit<ToastProps, 'message'>>
+  ) => {
+    return addToast({ ...options, message, type: 'custom' }); // Default to custom toast
   },
   {
-    success: (message: React.ReactNode, options?: Partial<any>) =>
-      addToast({ ...options, message, type: 'success' }),
-    error: (message: React.ReactNode, options?: Partial<any>) =>
-      addToast({ ...options, message, type: 'error' }),
-    info: (message: React.ReactNode, options?: Partial<any>) =>
-      addToast({ ...options, message, type: 'info' }),
-    envelope: (message: React.ReactNode, options?: Partial<any>) =>
-      addToast({ ...options, message, type: 'envelope' }),
-    drawer: (message: React.ReactNode, options?: Partial<any>) =>
-      addToast({ ...options, message, type: 'drawer' }),
-    warning: (message: React.ReactNode, options?: Partial<any>) =>
-      addToast({ ...options, message, type: 'warning' }),
-    custom: (message: React.ReactNode, options?: Partial<any>) =>
-      addToast({ ...options, message, type: 'custom' }),
+    success: (
+      message: React.ReactNode,
+      options?: Partial<Omit<ToastProps, 'message' | 'type'>>
+    ) => addToast({ ...options, message, type: 'success' }),
+    error: (
+      message: React.ReactNode,
+      options?: Partial<Omit<ToastProps, 'message' | 'type'>>
+    ) => addToast({ ...options, message, type: 'error' }),
+    info: (
+      message: React.ReactNode,
+      options?: Partial<Omit<ToastProps, 'message' | 'type'>>
+    ) => addToast({ ...options, message, type: 'info' }),
+    envelope: (
+      message: React.ReactNode,
+      options?: Partial<Omit<ToastProps, 'message' | 'type'>>
+    ) => addToast({ ...options, message, type: 'envelope' }),
+    drawer: (
+      message: React.ReactNode,
+      options?: Partial<Omit<ToastProps, 'message' | 'type'>>
+    ) => addToast({ ...options, message, type: 'drawer' }),
+    warning: (
+      message: React.ReactNode,
+      options?: Partial<Omit<ToastProps, 'message' | 'type'>>
+    ) => addToast({ ...options, message, type: 'warning' }),
+    custom: (
+      message: React.ReactNode,
+      options?: Partial<Omit<ToastProps, 'message' | 'type'>>
+    ) => addToast({ ...options, message, type: 'custom' }),
     remove: (id: string) => removeToast(id),
     removeAll: () => removeAllToast(),
     update: (id: string, updates: Partial<any>) => updateToast(id, updates),
@@ -34,7 +52,7 @@ export const toast = Object.assign(
     remainingTime: (id: string) => getRemainingTimeForToast(id),
     resume: (id: string) => resumeToastTimer(id),
     promise: (
-      promise: Promise<any>,
+      promise: Promise<void>,
       {
         loading,
         success,
@@ -53,24 +71,24 @@ export const toast = Object.assign(
       // Show the loading toast indefinitely
       const loadingToastId = addToast({
         message: loading,
-        type: "promise",
+        type: 'promise',
         position,
         ...toastOptions,
         duration: Infinity, // Ensure loading toast doesn't disappear
       });
-    
+
       promise
-        .then((res) => {
+        .then(() => {
           updateToast(loadingToastId, {
             message: success,
-            type: "success",
+            type: 'success',
             duration: toastOptions.duration ?? 3000, // Use toastOptions.duration
           });
         })
-        .catch((err) => {
+        .catch(() => {
           updateToast(loadingToastId, {
             message: error,
-            type: "error",
+            type: 'error',
             duration: toastOptions.duration ?? 3000, // Use toastOptions.duration
           });
         });

--- a/src/components/toast.ts
+++ b/src/components/toast.ts
@@ -6,6 +6,7 @@ import {
   resumeToastTimer,
   removeAllToast,
   getRemainingTimeForToast,
+  Toast,
 } from './toast-store';
 import { ToastProps } from './types';
 
@@ -47,12 +48,12 @@ export const toast = Object.assign(
     ) => addToast({ ...options, message, type: 'custom' }),
     remove: (id: string) => removeToast(id),
     removeAll: () => removeAllToast(),
-    update: (id: string, updates: Partial<any>) => updateToast(id, updates),
+    update: (id: string, updates: Partial<Toast>) => updateToast(id, updates),
     pause: (id: string) => pauseToastTimer(id),
     remainingTime: (id: string) => getRemainingTimeForToast(id),
     resume: (id: string) => resumeToastTimer(id),
-    promise: (
-      promise: Promise<void>,
+    promise: <T = void>(
+      promise: Promise<T>,
       {
         loading,
         success,
@@ -65,7 +66,7 @@ export const toast = Object.assign(
         error: string;
         duration?: number;
         position?: any;
-        toastOptions?: Partial<any>;
+        toastOptions?: Partial<ToastProps>;
       }
     ) => {
       // Show the loading toast indefinitely

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { createElement } from 'react';
 import { setup } from 'goober';
+import { ToastPosition } from './components/types';
 setup(createElement);
 
 export * from './components/toast-container';
 export * from './components/toast';
+export { ToastPosition };


### PR DESCRIPTION
This change set adds strong typing to the `toast` method and associated methods, assigns the type fed to the Promise-based resolution method as `void` and runs prettier on the file.

Let me know if the scope is too broad.